### PR TITLE
swtch: depend on asmdefines.h

### DIFF
--- a/kernel/Makefrag
+++ b/kernel/Makefrag
@@ -131,6 +131,8 @@ $(O)/kernel/initcode: $(O)/lib/sysstubs.o
 
 $(O)/kernel/bootother: TTEXT = 0x7000
 
+$(O)/kernel/swtch.o: $(O)/include/asmdefines.h
+
 $(O)/kernel/%: kernel/%.S $(O)/sysroot
 	@echo "  CC     $@"
 	$(Q)mkdir -p $(@D)


### PR DESCRIPTION
swtch.o needs asmdefines.h to be generated, but no dependency was declared on it.

Without this, a clean build produces the following error:
```
  CC     o.qemu/kernel/swtch.o
kernel/swtch.S:2:10: fatal error: asmdefines.h: No such file or directory
 #include "asmdefines.h"
          ^~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:150: o.qemu/kernel/swtch.o] Error 1
```