### PR TITLE
use correct baud rate and other fixes

### DIFF
--- a/include/lb.hh
+++ b/include/lb.hh
@@ -4,6 +4,12 @@
 #include "rnd.hh"
 #include "percpu.hh"
 
+#if NCPU_PER_SOCKET < 1
+// we need at least one CPU per socket for the assumptions made by the load
+// balancer code here to work.
+#error Cannot set NSOCKET larger than NCPU
+#endif
+
 template<int N>
 struct random_permutation {
  public:

--- a/kernel/kalloc.cc
+++ b/kernel/kalloc.cc
@@ -1006,6 +1006,10 @@ initkalloc(void)
     // Divide the node into at least subnodes buddy allocators
 #if KALLOC_BUDDY_PER_CPU
     size_t subnodes = node.cpus.size();
+    // Even if we have fewer CPUs than NUMA nodes, we still need to set up at
+    // least one buddy allocator per node.
+    if (subnodes == 0)
+      subnodes = 1;
 #else
     size_t subnodes = 1;
 #endif

--- a/param.h
+++ b/param.h
@@ -120,6 +120,7 @@
 #define NCPU          40  // maximum number of CPUs
 #define NSOCKET       2
 #define PERFSIZE      (128<<20ull)
+#define UART_BAUD     115200
 
 //
 // Linux user-space targets (no kernel, so most options aren't set)


### PR DESCRIPTION
As with some of the other hardware targets, bhw2 needs to use 115200 baud for compatibility with serial-over-lan. As well, this includes some fixes about handling different numbers of CPUs.