### PR TITLE
Runtime config syscall

### DIFF
--- a/bin/Makefrag
+++ b/bin/Makefrag
@@ -71,6 +71,7 @@ UPROGS_BIN= \
 	memsetbench \
 	update_ucode \
 	sharedtest \
+  param \
 
 ifeq ($(HAVE_LWIP),y)
 UPROGS_BIN += \

--- a/bin/Makefrag
+++ b/bin/Makefrag
@@ -71,7 +71,7 @@ UPROGS_BIN= \
 	memsetbench \
 	update_ucode \
 	sharedtest \
-  param \
+	param \
 
 ifeq ($(HAVE_LWIP),y)
 UPROGS_BIN += \

--- a/bin/param.cc
+++ b/bin/param.cc
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+#include "user.h"
+
+int
+main(int argc, char *argv[])
+{
+  switch(argc) {
+  case 1: // view all
+    cmdline_view_param(NULL);
+    break;
+  case 2: // view one
+    cmdline_view_param(argv[1]);
+    break;
+  case 3: // change one
+    cmdline_change_param(argv[1], argv[2]);
+    break;
+  default:
+    printf("Usage: param [name] [value]        view/change system parameters\n");
+    exit(2);
+  }
+  return 0;
+}

--- a/include/apic.hh
+++ b/include/apic.hh
@@ -34,6 +34,12 @@ public:
     send_ipi(c, T_SAMPCONF);
   }
 
+  // Send a T_PAUSE IPI to a remote CPU
+  void send_pause(struct cpu *c)
+  {
+    send_ipi(c, T_PAUSE);
+  }
+
   // Mask or unmask PC
   virtual void mask_pc(bool mask) = 0;
 

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -82,6 +82,10 @@ void            cgaputc(int c);
 // vga.c
 void            vgaputc(int c);
 
+// cmdline.cc
+int             cmdline_view_param(const char *name);
+int             cmdline_change_param(const char *name, const char *value);
+
 // console.c
 void            cprintf(const char*, ...) __attribute__((format(printf, 1, 2)));
 void            __cprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -131,6 +131,7 @@ long            futexwake(futexkey_t key, u64 nwake);
 extern char*    qtext;
 extern u8       secrets_mapped;
 void            remove_fsgsbase(void);
+void            apply_hotpatches(void);
 
 // hz.c
 void            microdelay(u64);

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -143,6 +143,14 @@ void            ideintr(void);
 struct proc *   idleproc(void);
 void            idlezombie(struct proc*);
 
+// ipi.cc
+void            pause_other_cpus(void);
+void            resume_other_cpus(void);
+// the following are only supposed to be used in trap.cc
+void            increment_paused_cpu_counter(void);
+bool            is_paused(void);
+void            decrement_paused_cpu_counter(void);
+
 // kalloc.c
 char*           kalloc(const char *name, size_t size = PGSIZE);
 void            kfree(void*, size_t size = PGSIZE);

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -145,12 +145,7 @@ struct proc *   idleproc(void);
 void            idlezombie(struct proc*);
 
 // ipi.cc
-void            pause_other_cpus(void);
-void            resume_other_cpus(void);
-// the following are only supposed to be used in trap.cc
-void            increment_paused_cpu_counter(void);
-bool            is_paused(void);
-void            decrement_paused_cpu_counter(void);
+void            pause_other_cpus_and_call(void (*fn)(void));
 
 // kalloc.c
 char*           kalloc(const char *name, size_t size = PGSIZE);

--- a/include/traps.h
+++ b/include/traps.h
@@ -27,6 +27,7 @@
 #define T_TLBFLUSH      65      // flush TLB
 #define T_SAMPCONF      66      // configure event counters
 #define T_IPICALL       67      // Queued IPI call
+#define T_PAUSE         68      // pause cpu
 #define T_DEFAULT      500      // catchall
 
 #define T_IRQ0          32      // IRQ 0 corresponds to int T_IRQ

--- a/kernel/cmdline.cc
+++ b/kernel/cmdline.cc
@@ -30,9 +30,10 @@ void dummy() {
 
 struct param_metadata<bool> binary_params[] = {
   { "disable_pcid",    &cmdline_params.disable_pcid,    false, dummy },
-  { "keep_retpolines", &cmdline_params.keep_retpolines, false, NULL },
+  { "keep_retpolines", &cmdline_params.keep_retpolines, false, apply_hotpatches },
+  { "lazy_barrier",    &cmdline_params.lazy_barrier,    true,  apply_hotpatches },
   { "use_vga",         &cmdline_params.use_vga,         true,  NULL },
-  { "mitigate_mds",    &cmdline_params.mds,             true,  NULL },
+  { "mitigate_mds",    &cmdline_params.mds,             true,  apply_hotpatches },
 };
 
 struct param_metadata<u64> uint_params[] = {};

--- a/kernel/cmdline.cc
+++ b/kernel/cmdline.cc
@@ -175,7 +175,8 @@ change_binary_param(struct param_metadata<bool> *param, const char *value)
 
   if (new_val != *param->pval) {
     *param->pval = new_val;
-    pause_other_cpus_and_call(param->on_change);
+    if (param->on_change != NULL)
+      pause_other_cpus_and_call(param->on_change);
   }
 }
 
@@ -186,7 +187,8 @@ change_uint_param(struct param_metadata<u64> *param, const char *value)
 
   if (new_val != *param->pval) {
     *param->pval = new_val;
-    pause_other_cpus_and_call(param->on_change);
+    if (param->on_change != NULL)
+      pause_other_cpus_and_call(param->on_change);
   }
 }
 
@@ -197,7 +199,8 @@ change_string_param(struct param_metadata<char *> *param, const char *value)
   if (strcmp(new_val, value) != 0) {
     strncpy(new_val, value, CMDLINE_VALUE);
     new_val[CMDLINE_VALUE - 1] = '\0';
-    pause_other_cpus_and_call(param->on_change);
+    if (param->on_change != NULL)
+      pause_other_cpus_and_call(param->on_change);
   }
 }
 

--- a/kernel/cmdline.cc
+++ b/kernel/cmdline.cc
@@ -166,16 +166,6 @@ cmdline_view_param(const char *name)
 }
 
 void
-pause_and_call(void (*fn)(void))
-{
-  if (fn != NULL) {
-    pause_other_cpus();
-    fn();
-    resume_other_cpus();
-  }
-}
-
-void
 change_binary_param(struct param_metadata<bool> *param, const char *value)
 {
   bool new_val = *param->pval;
@@ -185,7 +175,7 @@ change_binary_param(struct param_metadata<bool> *param, const char *value)
 
   if (new_val != *param->pval) {
     *param->pval = new_val;
-    pause_and_call(param->on_change);
+    pause_other_cpus_and_call(param->on_change);
   }
 }
 
@@ -196,7 +186,7 @@ change_uint_param(struct param_metadata<u64> *param, const char *value)
 
   if (new_val != *param->pval) {
     *param->pval = new_val;
-    pause_and_call(param->on_change);
+    pause_other_cpus_and_call(param->on_change);
   }
 }
 
@@ -207,7 +197,7 @@ change_string_param(struct param_metadata<char *> *param, const char *value)
   if (strcmp(new_val, value) != 0) {
     strncpy(new_val, value, CMDLINE_VALUE);
     new_val[CMDLINE_VALUE - 1] = '\0';
-    pause_and_call(param->on_change);
+    pause_other_cpus_and_call(param->on_change);
   }
 }
 

--- a/kernel/ipi.cc
+++ b/kernel/ipi.cc
@@ -139,11 +139,10 @@ resume_other_cpus(void)
 void
 pause_other_cpus_and_call(void (*fn)(void))
 {
-  if (fn != NULL) {
-    pause_other_cpus();
-    fn();
-    resume_other_cpus();
-  }
+  assert(fn != NULL);
+  pause_other_cpus();
+  fn();
+  resume_other_cpus();
 }
 
 void

--- a/kernel/ipi.cc
+++ b/kernel/ipi.cc
@@ -150,8 +150,7 @@ pause_cpu(void)
 {
   if (DEBUG)
     cprintf("pausing cpu %d\n", mycpu()->id);
-  paused_cpu_counter++;
-  if (paused_cpu_counter == ncpu - 1)
+  if (++paused_cpu_counter == ncpu - 1)
     pause_state = Paused;
 
   // spin until the core that called pause_other_cpus_and_call is done
@@ -159,7 +158,6 @@ pause_cpu(void)
 
   if (DEBUG)
     cprintf("resuming cpu %d\n", mycpu()->id);
-  paused_cpu_counter--;
-  if (paused_cpu_counter == 0)
+  if (--paused_cpu_counter == 0)
     pause_state = Unpaused;
 }

--- a/kernel/ipi.cc
+++ b/kernel/ipi.cc
@@ -91,7 +91,16 @@ on_ipicall()
   }
 }
 
-/* Logic for implementing pause_other_cpus_and_call */
+/* Logic for implementing pause_other_cpus_and_call
+
+ The core that calls pause_other_cpus_and_call changes the
+ state from Ready to Pausing, Paused to Unpausing, and
+ Unpaused to Ready.
+
+ Of the remaining cores, the last one to pause/unpause will
+ change the state from Pausing to Paused and Unpausing to
+ Unpaused respectively.
+ */
 std::atomic<int> paused_cpu_counter {0};
 enum pause_state_t { Ready, Pausing, Paused, Unpausing, Unpaused };
 std::atomic<pause_state_t> pause_state {Ready};

--- a/kernel/sysproc.cc
+++ b/kernel/sysproc.cc
@@ -13,6 +13,7 @@
 #include "filetable.hh"
 #include "ipi.hh"
 #include "cpuid.hh"
+#include "cmdline.hh"
 
 #include <uk/mman.h>
 #include <uk/utsname.h>
@@ -411,4 +412,18 @@ sys_update_microcode(const void* data, u64 len)
   run_on_cpus(remote_cpus, install_microcode);
   kfree(microcode);
   return 0;
+}
+
+//SYSCALL
+int
+sys_cmdline_view_param(const char *name)
+{
+  return cmdline_view_param(name);
+}
+
+//SYSCALL
+int
+sys_cmdline_change_param(const char *name, const char *value)
+{
+  return cmdline_change_param(name, value);
 }

--- a/kernel/trap.cc
+++ b/kernel/trap.cc
@@ -278,14 +278,9 @@ trap(struct trapframe *tf, bool had_secrets)
     sampconf();
     break;
   case T_PAUSE:
+    extern void pause_cpu(); // ipi.cc
     lapiceoi();
-    if (DEBUG)
-      cprintf("pausing cpu %d\n", mycpu()->id);
-    increment_paused_cpu_counter();
-    while (is_paused());
-    if (DEBUG)
-      cprintf("unpausing cpu %d\n", mycpu()->id);
-    decrement_paused_cpu_counter();
+    pause_cpu();
     break;
   case T_IPICALL: {
     extern void on_ipicall();

--- a/kernel/trap.cc
+++ b/kernel/trap.cc
@@ -277,6 +277,16 @@ trap(struct trapframe *tf, bool had_secrets)
     lapiceoi();
     sampconf();
     break;
+  case T_PAUSE:
+    lapiceoi();
+    if (DEBUG)
+      cprintf("pausing cpu %d\n", mycpu()->id);
+    increment_paused_cpu_counter();
+    while (is_paused());
+    if (DEBUG)
+      cprintf("unpausing cpu %d\n", mycpu()->id);
+    decrement_paused_cpu_counter();
+    break;
   case T_IPICALL: {
     extern void on_ipicall();
     lapiceoi();

--- a/lib/string.c
+++ b/lib/string.c
@@ -232,3 +232,44 @@ strtol(const char *s, char **endptr, int base)
     *endptr = (char *) s;
   return (neg ? -val : val);
 }
+
+unsigned long int
+strtoul(const char *s, char **endptr, int base)
+{
+  unsigned long val = 0;
+
+  // gobble initial whitespace
+  while (*s && strchr(" \n\r\t\f\v", *s))
+    s++;
+
+  // hex or octal base prefix
+  if ((base == 0 || base == 16) && (s[0] == '0' && s[1] == 'x'))
+    s += 2, base = 16;
+  else if (base == 0 && s[0] == '0')
+    s++, base = 8;
+  else if (base == 0)
+    base = 10;
+
+  // digits
+  while (1) {
+    int dig;
+
+    if (*s >= '0' && *s <= '9')
+      dig = *s - '0';
+    else if (*s >= 'a' && *s <= 'z')
+      dig = *s - 'a' + 10;
+    else if (*s >= 'A' && *s <= 'Z')
+      dig = *s - 'A' + 10;
+    else
+      break;
+    if (dig >= base)
+      break;
+    s++;
+    val = (val * base) + dig;
+    // we don't properly detect overflow!
+  }
+
+  if (endptr)
+    *endptr = (char *) s;
+  return val;
+}

--- a/stdinc/string.h
+++ b/stdinc/string.h
@@ -27,6 +27,7 @@ int strncmp(const char *p, const char *q, size_t n);
 char *strstr(const char *haystack, const char *needle);
 
 long int strtol(const char *s, char **endptr, int base);
+unsigned long int strtoul(const char *s, char **endptr, int base);
 
 // Not C11
 void *mempcpy(void *dest, const void *src, size_t n);


### PR DESCRIPTION
Sets up a framework for changing cmdline params at runtime  #13 .

A user space driver program `param` interfaces with the system calls `cmdline_view_param` and `cmdline_change_param`.

For each param, an optional hook can be specified. The hook is run whenever the value of the param is changed. While the hook is running, other cores are paused (spun in a while loop) until the hook is complete.  