### PR TITLE
TSC cleanup

### DIFF
--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -139,8 +139,9 @@ void            remove_fsgsbase(void);
 void            apply_hotpatches(void);
 
 // hz.c
-void            microdelay(u64);
-void            inithz(void);
+//void            inithz(void);
+//condvar.cc
+void microdelay(u64 delay);
 
 // ide.c
 void            ideintr(void);

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -139,7 +139,7 @@ void            remove_fsgsbase(void);
 void            apply_hotpatches(void);
 
 //condvar.cc
-void microdelay(u64 delay);
+void            microdelay(u64 delay);
 
 // ide.c
 void            ideintr(void);

--- a/include/kernel.hh
+++ b/include/kernel.hh
@@ -138,8 +138,6 @@ extern u8       secrets_mapped;
 void            remove_fsgsbase(void);
 void            apply_hotpatches(void);
 
-// hz.c
-//void            inithz(void);
 //condvar.cc
 void microdelay(u64 delay);
 

--- a/kernel/Makefrag
+++ b/kernel/Makefrag
@@ -22,7 +22,6 @@ OBJS = \
 	ioapic.o \
 	hotpatch.o \
 	hwvm.o \
-	hz.o \
 	kalloc.o \
 	kmalloc.o \
 	kbd.o \

--- a/kernel/condvar.cc
+++ b/kernel/condvar.cc
@@ -9,7 +9,6 @@
 #include "hpet.hh"
 
 #define TSC_PERIOD_SCALE 0x10000
-u64 cpuhz;
 
 // Intel 8253/8254/82C54 Programmable Interval Timer (PIT).
 // http://en.wikipedia.org/wiki/Intel_8253
@@ -24,6 +23,7 @@ u64 cpuhz;
 #define TIMER_STAT      0xe0    // read status mode
 #define TIMER_STAT0     (TIMER_STAT | 0x2)  // status mode counter 0
 
+u64 cpuhz;
 static u64 ticks __mpalign__;
 
 ilist<proc,&proc::cv_sleep> sleepers  __mpalign__;   // XXX one per core?

--- a/kernel/condvar.cc
+++ b/kernel/condvar.cc
@@ -217,9 +217,7 @@ void
 inittsc(void)
 {
   cpuhz  = gethzfromPIT();
-  cprintf("HPET PIT: %lu\n", cpuhz);
   if (the_hpet) {
-    cprintf("USING HPET\n");
     u64 hpet_start = the_hpet->read_nsec();
     u64 tsc_start = rdtsc();
 
@@ -227,14 +225,11 @@ inittsc(void)
     do {
       nop_pause();
       hpet_end = the_hpet->read_nsec();
-    } while(hpet_end < hpet_start + 50000);
+    } while(hpet_end < hpet_start + 50000000);
     u64 tsc_end = rdtsc();
-    mycpu()->tsc_period = ((tsc_end - tsc_start) * TSC_PERIOD_SCALE
-      / (hpet_end - hpet_start)) ;
-    cprintf("HPET TSC: %lu\n", mycpu()->tsc_period);
-    cprintf("PIT TSC: %lu\n", (cpuhz*TSC_PERIOD_SCALE)/1000000000);
+    mycpu()->tsc_period = (tsc_end - tsc_start) * TSC_PERIOD_SCALE
+      / (hpet_end - hpet_start);
   } else {
-    mycpu()->tsc_period = (cpuhz*TSC_PERIOD_SCALE/1000000000);
-    cprintf("PIT TSC: %lu\n", mycpu()->tsc_period);
+    mycpu()->tsc_period = (cpuhz * TSC_PERIOD_SCALE) / 1000000000;
   }
 }

--- a/kernel/main.cc
+++ b/kernel/main.cc
@@ -178,7 +178,6 @@ void
 cmain(u64 mbmagic, u64 mbaddr)
 {
   extern u64 cpuhz;
-
   // Make cpus[0] work.  CPU 0's percpu data is pre-allocated directly
   // in the image.  *cpu and such won't work until we inittls.
   percpu_offsets[0] = __percpu_start;
@@ -194,7 +193,7 @@ cmain(u64 mbmagic, u64 mbaddr)
   initvga();               // Requires initmultiboot, initcmdline
   initphysmem();           // Requires initmultiboot
   initpg(&cpus[0]);        // Requires initphysmem
-  inithz();                // CPU Hz, microdelay
+  //inithz();                // CPU Hz, microdelay
   initseg(&cpus[0]);
   inittls(&cpus[0]);       // Requires initseg
   initdoublebuffer();      // Requires initpg
@@ -261,7 +260,8 @@ cmain(u64 mbmagic, u64 mbaddr)
   initinode();     // inode cache
   initmfs();
 
-  if (VERBOSE)
+//  if (VERBOSE)
+  cprintf("tsc_period: %lu\n", mycpu()->tsc_period);
     cprintf("ncpu %d %lu MHz\n", ncpu, cpuhz / 1000000);
 
   inituser();      // first user process

--- a/kernel/main.cc
+++ b/kernel/main.cc
@@ -178,6 +178,7 @@ void
 cmain(u64 mbmagic, u64 mbaddr)
 {
   extern u64 cpuhz;
+
   // Make cpus[0] work.  CPU 0's percpu data is pre-allocated directly
   // in the image.  *cpu and such won't work until we inittls.
   percpu_offsets[0] = __percpu_start;
@@ -193,7 +194,6 @@ cmain(u64 mbmagic, u64 mbaddr)
   initvga();               // Requires initmultiboot, initcmdline
   initphysmem();           // Requires initmultiboot
   initpg(&cpus[0]);        // Requires initphysmem
-  //inithz();                // CPU Hz, microdelay
   initseg(&cpus[0]);
   inittls(&cpus[0]);       // Requires initseg
   initdoublebuffer();      // Requires initpg
@@ -260,8 +260,7 @@ cmain(u64 mbmagic, u64 mbaddr)
   initinode();     // inode cache
   initmfs();
 
-//  if (VERBOSE)
-  cprintf("tsc_period: %lu\n", mycpu()->tsc_period);
+  if (VERBOSE)
     cprintf("ncpu %d %lu MHz\n", ncpu, cpuhz / 1000000);
 
   inituser();      // first user process


### PR DESCRIPTION
-TSC frequency now calculated using cpuhz if hpet not available
-moved cpuhz calculation code to condvar.cc to consolidate. deleted hz.cc